### PR TITLE
Add persistent right-side UI with placeholder controls for skybox, env map, lights, and model selection

### DIFF
--- a/src/graphics/Engine.Config.cpp
+++ b/src/graphics/Engine.Config.cpp
@@ -1,6 +1,7 @@
 #include "Engine.hpp"
 
 #include <ranges>
+#include <algorithm>
 
 namespace m1
 {
@@ -27,6 +28,52 @@ namespace m1
 	void Engine::setLightingType(LightingType lightingType)	{ _config.lightingType = lightingType; }
 
 	LightingType Engine::getLightingType() const { return _config.lightingType;}
+
+	void Engine::setSkyboxEnabled(bool enabled) { _config.skyboxEnabled = enabled; }
+
+	bool Engine::getSkyboxEnabled() const { return _config.skyboxEnabled; }
+
+	void Engine::setEnvironmentMapIntensity(float intensity) { _config.environmentMapIntensity = std::max(0.0f, intensity); }
+
+	float Engine::getEnvironmentMapIntensity() const { return _config.environmentMapIntensity; }
+
+	void Engine::setEnvironmentMapPreset(EnvironmentMapPreset preset) { _config.environmentMapPreset = preset; }
+
+	EnvironmentMapPreset Engine::getEnvironmentMapPreset() const { return _config.environmentMapPreset; }
+
+	void Engine::setSelectedModelIndex(int modelIndex) { _config.selectedModelIndex = std::max(0, modelIndex); }
+
+	int Engine::getSelectedModelIndex() const { return _config.selectedModelIndex; }
+
+	void Engine::setAmbientLight(const glm::vec4& ambient) { _lightsUbo.ambient = ambient; }
+
+	glm::vec4 Engine::getAmbientLight() const { return _lightsUbo.ambient; }
+
+	void Engine::setLight(uint32_t index, const Light& light)
+	{
+		if (index >= MAX_LIGHTS)
+			return;
+
+		_lightsUbo.lights[index] = light;
+	}
+
+	Light Engine::getLight(uint32_t index) const
+	{
+		if (index >= MAX_LIGHTS)
+			return {};
+
+		return _lightsUbo.lights[index];
+	}
+
+	void Engine::setLightsCount(int lightsCount)
+	{
+		_lightsUbo.numLights = std::clamp(lightsCount, 0, MAX_LIGHTS);
+	}
+
+	int Engine::getLightsCount() const
+	{
+		return std::clamp(_lightsUbo.numLights, 0, MAX_LIGHTS);
+	}
 
 	void Engine::setUiEnabled(bool enabled) { _config.uiEnabled = enabled; }
 

--- a/src/graphics/Engine.cpp
+++ b/src/graphics/Engine.cpp
@@ -850,7 +850,8 @@ namespace m1
 		// draw objects
 		drawObjectsLoop(commandBuffer);
 
-		drawSkyBox(commandBuffer); // TODO flag ui
+		if (_config.skyboxEnabled)
+			drawSkyBox(commandBuffer);
 
 		// draw particles
 		if (_config.particlesEnabled)

--- a/src/graphics/Engine.hpp
+++ b/src/graphics/Engine.hpp
@@ -30,13 +30,23 @@ namespace m1
 		Pbr,
 	};
 
+	enum class EnvironmentMapPreset
+	{
+		NewportLoft = 0,
+		Hdr111ParkingLot2Ref = 1,
+	};
+
 	struct EngineConfig
 	{
 		bool msaaEnabled = true;
 		bool shadowsEnabled = true;
 		bool particlesEnabled = true;
 		bool uiEnabled = true;
+		bool skyboxEnabled = true;
 		LightingType lightingType = LightingType::Pbr;
+		float environmentMapIntensity = 1.0f;
+		EnvironmentMapPreset environmentMapPreset = EnvironmentMapPreset::Hdr111ParkingLot2Ref;
+		int selectedModelIndex = 0;
 	};
 
     class Engine
@@ -81,6 +91,20 @@ namespace m1
         bool getShadowsEnabled() const;
         void setLightingType(LightingType lightingType);
         LightingType getLightingType() const;
+		void setSkyboxEnabled(bool enabled);
+		bool getSkyboxEnabled() const;
+		void setEnvironmentMapIntensity(float intensity);
+		float getEnvironmentMapIntensity() const;
+		void setEnvironmentMapPreset(EnvironmentMapPreset preset);
+		EnvironmentMapPreset getEnvironmentMapPreset() const;
+		void setSelectedModelIndex(int modelIndex);
+		int getSelectedModelIndex() const;
+		void setAmbientLight(const glm::vec4& ambient);
+		glm::vec4 getAmbientLight() const;
+		void setLight(uint32_t index, const Light& light);
+		Light getLight(uint32_t index) const;
+		void setLightsCount(int lightsCount);
+		int getLightsCount() const;
 
     private:
         void mainLoop();

--- a/src/graphics/UiModule.cpp
+++ b/src/graphics/UiModule.cpp
@@ -2,6 +2,7 @@
 #include "Queue.hpp"
 #include "Renderer.hpp"
 #include "Utils.hpp"
+#include <algorithm>
 
 static void check_vk_result(VkResult err)
 {
@@ -41,7 +42,20 @@ namespace m1
 		ImGui_ImplGlfw_NewFrame();
 		ImGui::NewFrame();
 
-		ImGui::Begin("Engine controls");
+		constexpr float minPanelWidth = 360.0f;
+		constexpr float preferredPanelWidth = 420.0f;
+		ImGuiIO& io = ImGui::GetIO();
+		float panelWidth = std::clamp(io.DisplaySize.x * 0.33f, minPanelWidth, preferredPanelWidth);
+		panelWidth = std::min(panelWidth, io.DisplaySize.x);
+
+		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x - panelWidth, 0.0f), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(panelWidth, io.DisplaySize.y), ImGuiCond_Always);
+		ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse;
+		ImGui::Begin("Engine controls", nullptr, windowFlags);
+		ImGui::PushItemWidth(-1.0f);
+
+		ImGui::TextUnformatted("Rendering");
+		ImGui::Separator();
 
 		bool enableMsaa = _engine.getMsaaEnabled();
 		if (ImGui::Checkbox("MSAA", &enableMsaa))
@@ -61,6 +75,12 @@ namespace m1
 			_engine.setShadowsEnabled(shadowsEnabled);
 		}
 
+		bool skyboxEnabled = _engine.getSkyboxEnabled();
+		if (ImGui::Checkbox("Skybox", &skyboxEnabled))
+		{
+			_engine.setSkyboxEnabled(skyboxEnabled);
+		}
+
 		int lightingMode = _engine.getLightingType() == LightingType::BlinnPhong ? 0 : 1;
 		const char* lightingItems[] = {"Blinn-Phong", "PBR"};
 		if (ImGui::Combo("Lighting model", &lightingMode, lightingItems, IM_ARRAYSIZE(lightingItems)))
@@ -68,7 +88,98 @@ namespace m1
 			_engine.setLightingType(lightingMode == 0 ? LightingType::BlinnPhong : LightingType::Pbr);
 		}
 
-		ImGui::TextUnformatted("Note: shadow toggle is config-only right now.");
+		float envIntensity = _engine.getEnvironmentMapIntensity();
+		if (ImGui::SliderFloat("Environment intensity", &envIntensity, 0.0f, 10.0f, "%.2f"))
+		{
+			_engine.setEnvironmentMapIntensity(envIntensity);
+		}
+
+		int envMapPreset = _engine.getEnvironmentMapPreset() == EnvironmentMapPreset::NewportLoft ? 0 : 1;
+		const char* envMapItems[] = {"newport_loft", "HDR_111_Parking_Lot_2_Ref"};
+		if (ImGui::Combo("Environment map", &envMapPreset, envMapItems, IM_ARRAYSIZE(envMapItems)))
+		{
+			_engine.setEnvironmentMapPreset(envMapPreset == 0
+				? EnvironmentMapPreset::NewportLoft
+				: EnvironmentMapPreset::Hdr111ParkingLot2Ref);
+		}
+
+		ImGui::Spacing();
+		ImGui::TextUnformatted("Scene");
+		ImGui::Separator();
+
+		// Placeholder list: user will replace with desired model list.
+		int selectedModelIndex = _engine.getSelectedModelIndex();
+		const char* gltfModels[] = {"DamagedHelmet.glb", "Model_2.glb", "Model_3.glb"};
+		if (ImGui::Combo("GLTF model", &selectedModelIndex, gltfModels, IM_ARRAYSIZE(gltfModels)))
+		{
+			_engine.setSelectedModelIndex(selectedModelIndex);
+		}
+
+		ImGui::Spacing();
+		ImGui::TextUnformatted("Lights");
+		ImGui::Separator();
+
+		int lightsCount = _engine.getLightsCount();
+		if (ImGui::SliderInt("Lights count", &lightsCount, 0, MAX_LIGHTS))
+		{
+			_engine.setLightsCount(lightsCount);
+		}
+
+		glm::vec4 ambient = _engine.getAmbientLight();
+		float ambientColor[3] = {ambient.r, ambient.g, ambient.b};
+		if (ImGui::ColorEdit3("Ambient color", ambientColor))
+		{
+			ambient.r = ambientColor[0];
+			ambient.g = ambientColor[1];
+			ambient.b = ambientColor[2];
+			_engine.setAmbientLight(ambient);
+		}
+		if (ImGui::SliderFloat("Ambient intensity", &ambient.a, 0.0f, 2.0f, "%.2f"))
+		{
+			_engine.setAmbientLight(ambient);
+		}
+
+		for (int i = 0; i < std::min(lightsCount, 2); ++i)
+		{
+			Light light = _engine.getLight(static_cast<uint32_t>(i));
+			if (ImGui::TreeNode(std::format("Light {}", i).c_str()))
+			{
+				bool directional = light.posDir.w == 0.0f;
+				if (ImGui::Checkbox(std::format("Directional##{}", i).c_str(), &directional))
+				{
+					light.posDir.w = directional ? 0.0f : 1.0f;
+					_engine.setLight(i, light);
+				}
+
+				if (ImGui::DragFloat3(std::format("Pos/Dir##{}", i).c_str(), &light.posDir.x, 0.05f))
+				{
+					_engine.setLight(i, light);
+				}
+
+				float lightColor[3] = {light.color.r, light.color.g, light.color.b};
+				if (ImGui::ColorEdit3(std::format("Color##{}", i).c_str(), lightColor))
+				{
+					light.color.r = lightColor[0];
+					light.color.g = lightColor[1];
+					light.color.b = lightColor[2];
+					_engine.setLight(i, light);
+				}
+				if (ImGui::SliderFloat(std::format("Intensity##{}", i).c_str(), &light.color.a, 0.0f, 10.0f, "%.2f"))
+				{
+					_engine.setLight(i, light);
+				}
+
+				if (ImGui::DragFloat3(std::format("Attenuation##{}", i).c_str(), &light.attenuation.x, 0.001f, 0.0f, 2.0f, "%.3f"))
+				{
+					_engine.setLight(i, light);
+				}
+				ImGui::TreePop();
+			}
+		}
+
+		ImGui::Spacing();
+		ImGui::TextUnformatted("Note: UI wiring only; engine-side feature logic is still to be implemented.");
+		ImGui::PopItemWidth();
 		ImGui::End();
 
 		ImGui::Render();


### PR DESCRIPTION
### Motivation
- Provide an always-visible, non-overlapping UI panel anchored to the right side of the window so scene and UI don't conflict. 
- Expose UI controls for environment and scene parameters so users can toggle/adjust features and pick models from the UI. 
- Wire UI controls to engine properties so interactions can be implemented later without changing the UI again. 

### Description
- Reworked the ImGui controls into a fixed right-side panel by setting window position/size and using `ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize` in `src/graphics/UiModule.cpp` and grouped controls into Rendering / Scene / Lights sections. 
- Added UI controls for `Skybox` on/off, `Environment intensity` slider, environment preset combo (`newport_loft` / `HDR_111_Parking_Lot_2_Ref`), a placeholder `GLTF model` combo, and light editing UI (lights count, ambient color/intensity, per-light pos/dir, color, intensity, attenuation). 
- Added engine-side config and API plumbing: new `EnvironmentMapPreset` enum, `skyboxEnabled`, `environmentMapIntensity`, `environmentMapPreset`, and `selectedModelIndex` fields in `EngineConfig`, plus getters/setters and light/ambient accessors implemented in `src/graphics/Engine.hpp` and `src/graphics/Engine.Config.cpp`. 
- Gated skybox rendering behind the new flag by checking `_config.skyboxEnabled` before calling `drawSkyBox` in `src/graphics/Engine.cpp`. 
- The UI currently only calls engine setters/getters; actual runtime logic (environment rebake/swap, descriptor updates, model loading/replacement, GPU light buffer uploads) is intentionally left unimplemented for follow-up. 

### Testing
- Ran CMake configure and build (`cmake -S . -B build && cmake --build build -j2`), and configuration failed due to missing Vulkan SDK/libraries on the host environment (error: `Could NOT find Vulkan`).
- No other automated tests were present or executed in this environment, and no runtime validation could be performed because the build could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40f128c5c8328b8c57306c9da93c0)